### PR TITLE
Move all configs to use Config for env and yaml

### DIFF
--- a/cloudendure/config.py
+++ b/cloudendure/config.py
@@ -42,6 +42,10 @@ class CloudEndureConfig:
                     "project_name": "",
                     "project_id": "",
                     "max_lag_ttl": "90",
+                    "machines": "",
+                    "migration_wave": "0",
+                    "clone_status": "NOT_STARTED",
+                    "destination_accounts": "",
                 }
             )
         self.update_config()

--- a/cloudendure/utils.py
+++ b/cloudendure/utils.py
@@ -2,8 +2,10 @@
 """Define the CloudEndure utility logic.
 
 Attributes:
-    first_cap_re ():
-    all_cap_re ():
+    first_cap_re (re.Pattern): The regex pattern to determine the first capital
+        letter in a string.
+    all_cap_re (re.Pattern): The regex pattern to determine all capital letters
+        in a string.
 
 """
 import re
@@ -16,7 +18,12 @@ all_cap_re = re.compile("([a-z0-9])([A-Z])")
 
 
 def get_time_now() -> Dict[str, Any]:
-    """Get the current time in UTC as milliseconds."""
+    """Get the current time in UTC as milliseconds.
+
+    Returns:
+        dict: The mapping of time now values in UTC.
+
+    """
     time_now = time.time()
     data = {
         "seconds": time_now,
@@ -27,6 +34,14 @@ def get_time_now() -> Dict[str, Any]:
 
 
 def to_snake_case(value: str) -> str:
-    """Convert the provided value from CamelCase to snake_case."""
+    """Convert the provided value from CamelCase to snake_case.
+
+    Args:
+        value (str): The string value to convert from CamelCase to snake_case.
+
+    Returns:
+        str: The formatted snake_case string.
+
+    """
     s1 = first_cap_re.sub(r"\1_\2", value)
     return all_cap_re.sub(r"\1_\2", s1).lower()


### PR DESCRIPTION
The goal of this PR is to migrate all direct `os.environ.get()` specifically associated with `CLOUDENDURE_` variables to use `Config`

Additionally, this PR removes `cloudendure.cloudendure.CloudEndure.get_endpoint` which is an unused duplicate of `cloudendure.api.CloudEndureAPI.get_endpoint`
Fixes #28 