### PR TITLE
Update documentation with events entry and logos

### DIFF
--- a/pydocmd.yml
+++ b/pydocmd.yml
@@ -9,18 +9,20 @@ generate:
     - cloudendure.cloudendure++
   - code/cloudendure/config.md:
     - cloudendure.config++
+  - code/cloudendure/events.md:
+    - cloudendure.events++
   - code/cloudendure/exceptions.md:
     - cloudendure.exceptions++
   - code/cloudendure/models.md:
     - cloudendure.models++
   - code/cloudendure/utils.md:
     - cloudendure.utils++
-  - code/lambda/copy_ami.md:
-    - lambda.copy_ami++
-  - code/lambda/exceptions.md:
-    - lambda.exceptions++
-  - code/lambda/handler.md:
-    - lambda.handler++
+  - code/cloudendure/lambda/copy_ami.md:
+    - cloudendure.lambda.copy_ami++
+  - code/cloudendure/lambda/exceptions.md:
+    - cloudendure.lambda.exceptions++
+  - code/cloudendure/lambda/handler.md:
+    - cloudendure.lambda.handler++
 
 pages:
   - General:
@@ -32,13 +34,14 @@ pages:
       - API: code/cloudendure/api.md
       - Main: code/cloudendure/cloudendure.md
       - Config: code/cloudendure/config.md
+      - Events: code/cloudendure/events.md
       - Exceptions: code/cloudendure/exceptions.md
       - Models: code/cloudendure/models.md
       - Utilities: code/cloudendure/utils.md
     - AWS Lambda:
-      - Handler: code/lambda/handler.md
-      - Exceptions: code/lambda/exceptions.md
-      - Copy AMI Utils: code/lambda/copy_ami.md
+      - Handler: code/cloudendure/lambda/handler.md
+      - Exceptions: code/cloudendure/lambda/exceptions.md
+      - Copy AMI Utils: code/cloudendure/lambda/copy_ami.md
   - API Documentation:
     - MAIN: api/API_README.md << docs/API_README.md
     - AccountApi: api/AccountApi.md << docs/AccountApi.md
@@ -139,8 +142,8 @@ pages:
     - Security Policy: securitypolicy.md << SECURITY.md
 theme:
   name: material
-  logo: 'http://chittagongit.com/images/cloud-png-icon/cloud-png-icon-3.jpg'
-  favicon: 'http://chittagongit.com/images/cloud-png-icon/cloud-png-icon-3.jpg'
+  logo: 'https://img.icons8.com/ios-filled/100/000000/cloud-connection.png'
+  favicon: 'https://img.icons8.com/ios-filled/50/000000/cloud-connection.png'
   feature:
     tabs: true
 


### PR DESCRIPTION
The goal of this PR is to add the newly created `cloudendure.events.py` documentation to the pydocmd manifest for automatic documentation generation.

Additionally, this PR updates the documentation logo and favicon to use a public domain icon served over HTTPS.